### PR TITLE
Ends DesktopInfo64 process if it exists

### DIFF
--- a/desktopinfo/tools/chocolateybeforemodify.ps1
+++ b/desktopinfo/tools/chocolateybeforemodify.ps1
@@ -1,3 +1,7 @@
 ﻿if (Get-Process 'DesktopInfo' -ErrorAction SilentlyContinue) {
    Stop-Process -Name DesktopInfo -Force
 }
+
+if (Get-Process 'DesktopInfo64' -ErrorAction SilentlyContinue) {
+   Stop-Process -Name DesktopInfo64 -Force
+}


### PR DESCRIPTION
If the process is not ended, it won't get upgraded. So, it's necessary to end it.